### PR TITLE
Update RHEL_74 example to use cloud-init format for instance user_data

### DIFF
--- a/examples/oci/rhel74_image/datasources.tf
+++ b/examples/oci/rhel74_image/datasources.tf
@@ -46,3 +46,14 @@ data "external" "ipxe_gen" {
 		iso_url			 = "${var.iso_url}"
 	}
 }
+
+data "template_cloudinit_config" "cloudinit_config" {
+  gzip          = false
+  base64_encode = true
+
+  part {
+    filename     = "ipxe.sh"
+    content_type = "text/x-shellscript"
+    content      = "${file("ipxe.sh")}"
+  }
+}

--- a/examples/oci/rhel74_image/ipxe.tf
+++ b/examples/oci/rhel74_image/ipxe.tf
@@ -4,14 +4,14 @@ resource "oci_core_instance" "ipxe_node" {
   availability_domain = "${data.oci_identity_availability_domains.ad.availability_domains.0.name}"
   compartment_id      = "${data.oci_identity_compartments.compartment.compartments.0.id}"
   display_name        = "${var.ipxe_instance["name"]}"
-  image               = "${var.ipxe_image_ocid[var.region]}" 
+  image               = "${var.ipxe_image_ocid[var.region]}"
   shape               = "${var.ipxe_instance["shape"]}"
   subnet_id           = "${data.oci_core_subnets.subnet.subnets.0.id}"
   hostname_label      = "${var.ipxe_instance["hostname"]}"
 
   metadata {
     ssh_authorized_keys = "${var.ssh_public_key}"
-    user_data = "${base64encode(file(data.external.ipxe_gen.result["shell"]))}"
+    user_data = "${data.template_cloudinit_config.cloudinit_config.rendered}"
   }
 }
 
@@ -30,4 +30,3 @@ resource "null_resource" "delete_ipxe_destroy" {
     command = "rm -rf ./ipxe.sh"
   }
 }
-


### PR DESCRIPTION
Oracle Cloud Infrastructure compute instances now use Cloud Init for user_data, changing the format for user_data in this RHEL_74 example