### PR TITLE
Add copyright for aux files in regional_private_lb

### DIFF
--- a/examples/oci/regional_private_lb/db.zone.tmpl
+++ b/examples/oci/regional_private_lb/db.zone.tmpl
@@ -1,4 +1,5 @@
 ;
+; Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 ; Named file for custom entries in ha.oraclevcn.com
 ;
 $TTL    5S

--- a/examples/oci/regional_private_lb/dnsops/addserver
+++ b/examples/oci/regional_private_lb/dnsops/addserver
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 
 zonefile=$1
 ip=$2

--- a/examples/oci/regional_private_lb/dnsops/removeserver
+++ b/examples/oci/regional_private_lb/dnsops/removeserver
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 
 zonefile=$1
 ip=$2

--- a/examples/oci/regional_private_lb/lb_backends.tf
+++ b/examples/oci/regional_private_lb/lb_backends.tf
@@ -67,7 +67,7 @@ EOF
 
 resource "oci_load_balancer_backend" "lb1-be1" {
   load_balancer_id = "${oci_load_balancer.lb1.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb1-bes1.id}"
+  backendset_name  = "${oci_load_balancer_backendset.lb1-bes1.name}"
   ip_address       = "${oci_core_instance.instance1.private_ip}"
   port             = 80
   backup           = false
@@ -78,7 +78,7 @@ resource "oci_load_balancer_backend" "lb1-be1" {
 
 resource "oci_load_balancer_backend" "lb1-be2" {
   load_balancer_id = "${oci_load_balancer.lb1.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb1-bes1.id}"
+  backendset_name  = "${oci_load_balancer_backendset.lb1-bes1.name}"
   ip_address       = "${oci_core_instance.instance2.private_ip}"
   port             = 80
   backup           = false
@@ -91,7 +91,7 @@ resource "oci_load_balancer_backend" "lb1-be2" {
 
 resource "oci_load_balancer_backend" "lb2-be1" {
   load_balancer_id = "${oci_load_balancer.lb2.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb2-bes1.id}"
+  backendset_name  = "${oci_load_balancer_backendset.lb2-bes1.name}"
   ip_address       = "${oci_core_instance.instance1.private_ip}"
   port             = 80
   backup           = false
@@ -102,7 +102,7 @@ resource "oci_load_balancer_backend" "lb2-be1" {
 
 resource "oci_load_balancer_backend" "lb2-be2" {
   load_balancer_id = "${oci_load_balancer.lb2.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb2-bes1.id}"
+  backendset_name  = "${oci_load_balancer_backendset.lb2-bes1.name}"
   ip_address       = "${oci_core_instance.instance2.private_ip}"
   port             = 80
   backup           = false

--- a/examples/oci/regional_private_lb/lb_private.tf
+++ b/examples/oci/regional_private_lb/lb_private.tf
@@ -33,7 +33,7 @@ resource "oci_load_balancer_backendset" "lb1-bes1" {
 resource "oci_load_balancer_listener" "lb1-listener1" {
   load_balancer_id         = "${oci_load_balancer.lb1.id}"
   name                     = "http"
-  default_backend_set_name = "${oci_load_balancer_backendset.lb1-bes1.id}"
+  default_backend_set_name = "${oci_load_balancer_backendset.lb1-bes1.name}"
   port                     = "${var.ha_app_port}"
   protocol                 = "${upper(var.ha_app_protocol)}"
 }
@@ -69,7 +69,7 @@ resource "oci_load_balancer_backendset" "lb2-bes1" {
 resource "oci_load_balancer_listener" "lb2-listener1" {
   load_balancer_id         = "${oci_load_balancer.lb2.id}"
   name                     = "http"
-  default_backend_set_name = "${oci_load_balancer_backendset.lb2-bes1.id}"
+  default_backend_set_name = "${oci_load_balancer_backendset.lb2-bes1.name}"
   port                     = "${var.ha_app_port}"
   protocol                 = "${upper(var.ha_app_protocol)}"
 }

--- a/examples/oci/regional_private_lb/monitrc.tmpl
+++ b/examples/oci/regional_private_lb/monitrc.tmpl
@@ -1,3 +1,5 @@
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+
 set daemon  10              # check services at 10 seconds intervals
 set logfile syslog          # log to syslog
 include /etc/monit.d/*


### PR DESCRIPTION
Also uses name instead of id to reference backend sets, which
is necessary in more recent provider versions.