### PR TITLE
Update comments with UPL reference

### DIFF
--- a/examples/oci/connect_vcns_using_multiple_vnics/bridge.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/bridge.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 resource "oci_core_instance_configuration" "bridge_instance_configuration" {
   compartment_id = "${var.compartment_ocid}"
   display_name   = "BridgeInstance"

--- a/examples/oci/connect_vcns_using_multiple_vnics/datasources.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/datasources.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 data "oci_identity_availability_domains" "ADs" {
   compartment_id = "${var.tenancy_ocid}"
 }

--- a/examples/oci/connect_vcns_using_multiple_vnics/env-vars
+++ b/examples/oci/connect_vcns_using_multiple_vnics/env-vars
@@ -1,4 +1,5 @@
 ## Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved
+## Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 ### Provider credentials
 export TF_VAR_tenancy_ocid=""
 export TF_VAR_user_ocid=""

--- a/examples/oci/connect_vcns_using_multiple_vnics/output.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/output.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 # Outputing required info for users
 output "Bridge Instance Public IP" {
   value = "${data.oci_core_instance.bridge_instance.public_ip}"

--- a/examples/oci/connect_vcns_using_multiple_vnics/provider.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/provider.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 provider "oci" {
   version              = ">= 3.14"
   tenancy_ocid         = "${var.tenancy_ocid}"

--- a/examples/oci/connect_vcns_using_multiple_vnics/variables.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 variable "tenancy_ocid" {}
 
 variable "user_ocid" {}

--- a/examples/oci/connect_vcns_using_multiple_vnics/vcn1.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/vcn1.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 resource "oci_core_virtual_network" "CoreVCN" {
   cidr_block     = "${var.vcn_cidr}"
   compartment_id = "${var.compartment_ocid}"

--- a/examples/oci/connect_vcns_using_multiple_vnics/vcn2.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/vcn2.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 # Second VCN
 resource "oci_core_virtual_network" "CoreVCN2" {

--- a/examples/opc/bastion-host-provisioning/main.tf
+++ b/examples/opc/bastion-host-provisioning/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "user" {}
 variable "password" {}

--- a/examples/opc/bastion-host-provisioning/modules/bastion/bastion.tf
+++ b/examples/opc/bastion-host-provisioning/modules/bastion/bastion.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 resource "opc_compute_security_list" "bastion" {
   name                 = "bastion"

--- a/examples/opc/bastion-host-provisioning/modules/bastion/outputs.tf
+++ b/examples/opc/bastion-host-provisioning/modules/bastion/outputs.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 output "bastion_public_ip" {
   description = "Bastion host Public IP address"

--- a/examples/opc/bastion-host-provisioning/modules/bastion/variables.tf
+++ b/examples/opc/bastion-host-provisioning/modules/bastion/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "ssh_public_key" {
   description = "(Required) Name of existing SSH Key resource"

--- a/examples/opc/instance-from-colocated-snapshot/main.tf
+++ b/examples/opc/instance-from-colocated-snapshot/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 provider "opc" {
   user            = "${var.user}"

--- a/examples/opc/instance-from-colocated-snapshot/variables.tf
+++ b/examples/opc/instance-from-colocated-snapshot/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/opc/instance-from-storage-snapshot/main.tf
+++ b/examples/opc/instance-from-storage-snapshot/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 provider "opc" {
   user            = "${var.user}"

--- a/examples/opc/instance-from-storage-snapshot/variables.tf
+++ b/examples/opc/instance-from-storage-snapshot/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/opc/instance-with-persistent-boot-volume/main.tf
+++ b/examples/opc/instance-with-persistent-boot-volume/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 provider "opc" {
   user            = "${var.user}"

--- a/examples/opc/instance-with-persistent-boot-volume/variables.tf
+++ b/examples/opc/instance-with-persistent-boot-volume/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/opc/instance-with-public-ip-on-ip-network-interface/main.tf
+++ b/examples/opc/instance-with-public-ip-on-ip-network-interface/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 provider "opc" {
   user            = "${var.user}"

--- a/examples/opc/instance-with-public-ip-on-ip-network-interface/variables.tf
+++ b/examples/opc/instance-with-public-ip-on-ip-network-interface/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "user" {}
 variable "password" {}

--- a/examples/opc/instance-with-ssh/main.tf
+++ b/examples/opc/instance-with-ssh/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 provider "opc" {
   user            = "${var.user}"

--- a/examples/opc/instance-with-ssh/variables.tf
+++ b/examples/opc/instance-with-ssh/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/opc/ipnetworks/main.tf
+++ b/examples/opc/ipnetworks/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 provider "opc" {
   user            = "${var.user}"

--- a/examples/opc/ipnetworks/modules/install_ssh_keys/main.tf
+++ b/examples/opc/ipnetworks/modules/install_ssh_keys/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "trigger" {}
 variable "public_ip" {}

--- a/examples/opc/ipnetworks/variables.tf
+++ b/examples/opc/ipnetworks/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/opc/loadbalancer-classic/certificates/main.tf
+++ b/examples/opc/loadbalancer-classic/certificates/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 resource "tls_private_key" "example" {
   algorithm = "RSA"

--- a/examples/opc/loadbalancer-classic/certificates/outputs.tf
+++ b/examples/opc/loadbalancer-classic/certificates/outputs.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 output "ca_cert_pem" {
   value = "${tls_self_signed_cert.ca.cert_pem}"

--- a/examples/opc/loadbalancer-classic/certificates/variables.tf
+++ b/examples/opc/loadbalancer-classic/certificates/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "dns_names" {
   type = "list"

--- a/examples/opc/loadbalancer-classic/load_balancer/main.tf
+++ b/examples/opc/loadbalancer-classic/load_balancer/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 # main load balancer instance
 resource "opc_lbaas_load_balancer" "lb1" {

--- a/examples/opc/loadbalancer-classic/load_balancer/outputs.tf
+++ b/examples/opc/loadbalancer-classic/load_balancer/outputs.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 output "canonical_host_name" {
   value = "${opc_lbaas_load_balancer.lb1.canonical_host_name}"

--- a/examples/opc/loadbalancer-classic/load_balancer/variables.tf
+++ b/examples/opc/loadbalancer-classic/load_balancer/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "name" {}
 variable "region" {}

--- a/examples/opc/loadbalancer-classic/main.tf
+++ b/examples/opc/loadbalancer-classic/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 provider "opc" {
   version         = "~>1.2"

--- a/examples/opc/loadbalancer-classic/network/main.tf
+++ b/examples/opc/loadbalancer-classic/network/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 resource "opc_compute_ip_network" "ipnetwork" {
   name              = "${var.name}"

--- a/examples/opc/loadbalancer-classic/network/output.tf
+++ b/examples/opc/loadbalancer-classic/network/output.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 output "ipnetwork" {
   value = "${opc_compute_ip_network.ipnetwork.name}"

--- a/examples/opc/loadbalancer-classic/network/variables.tf
+++ b/examples/opc/loadbalancer-classic/network/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "name" {}
 variable "cidr" {}

--- a/examples/opc/loadbalancer-classic/outputs.tf
+++ b/examples/opc/loadbalancer-classic/outputs.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 output "server_ip_address" {
   value = "${module.server_pool.public_ip_addresses}"

--- a/examples/opc/loadbalancer-classic/security_rules/all_egress/main.tf
+++ b/examples/opc/loadbalancer-classic/security_rules/all_egress/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "name" {}
 variable "acl" {}

--- a/examples/opc/loadbalancer-classic/security_rules/main.tf
+++ b/examples/opc/loadbalancer-classic/security_rules/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "name_prefix" {}
 variable "acl" {}

--- a/examples/opc/loadbalancer-classic/server_pool/main.tf
+++ b/examples/opc/loadbalancer-classic/server_pool/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 resource "opc_compute_ssh_key" "sshkey" {
   name    = "${var.name}-ssh-key"

--- a/examples/opc/loadbalancer-classic/server_pool/outputs.tf
+++ b/examples/opc/loadbalancer-classic/server_pool/outputs.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 output "public_ip_addresses" {
   value = "${opc_compute_ip_address_reservation.ipres.*.ip_address}"

--- a/examples/opc/loadbalancer-classic/server_pool/variables.tf
+++ b/examples/opc/loadbalancer-classic/server_pool/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "public_ssh_key" {}
 

--- a/examples/opc/loadbalancer-classic/variables.tf
+++ b/examples/opc/loadbalancer-classic/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "user" {}
 variable "password" {}

--- a/examples/opc/loadbalancer-classic/webapp/main.tf
+++ b/examples/opc/loadbalancer-classic/webapp/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 locals {
   web_app_port = "80"

--- a/examples/opc/loadbalancer-classic/webapp/outputs.tf
+++ b/examples/opc/loadbalancer-classic/webapp/outputs.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 output "port" {
   value = "${local.web_app_port}"

--- a/examples/opc/loadbalancer-classic/webapp/variables.tf
+++ b/examples/opc/loadbalancer-classic/webapp/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "name" {}
 

--- a/examples/opc/marketplace-bitnami-elk/main.tf
+++ b/examples/opc/marketplace-bitnami-elk/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/opc/orchestrated-instance/main.tf
+++ b/examples/opc/orchestrated-instance/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "user" {}
 variable "password" {}

--- a/examples/opc/windows-instance-with-rdp/variables.tf
+++ b/examples/opc/windows-instance-with-rdp/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/opc/windows-instance-with-rdp/windows-server.tf
+++ b/examples/opc/windows-instance-with-rdp/windows-server.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 provider "opc" {
   user            = "${var.user}"

--- a/examples/oraclepaas/accs-go-app/go-service/start.sh
+++ b/examples/oraclepaas/accs-go-app/go-service/start.sh
@@ -1,4 +1,4 @@
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
-
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 go get github.com/ant0ine/go-json-rest/rest
 go run rest-service.go

--- a/examples/oraclepaas/accs-go-app/main.tf
+++ b/examples/oraclepaas/accs-go-app/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/accs-java-app/main.tf
+++ b/examples/oraclepaas/accs-java-app/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/accs-nodejs-app-from-git-repo/main.tf
+++ b/examples/oraclepaas/accs-nodejs-app-from-git-repo/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/accs-nodejs-app/main.tf
+++ b/examples/oraclepaas/accs-nodejs-app/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/accs-nodejs-app/node-app/myapp.js
+++ b/examples/oraclepaas/accs-nodejs-app/node-app/myapp.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
-
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 var http = require('http');
 // Read Environment Parameters
 var port = Number(process.env.PORT || 8080);

--- a/examples/oraclepaas/accs-php-app/main.tf
+++ b/examples/oraclepaas/accs-php-app/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/accs-python-app/main.tf
+++ b/examples/oraclepaas/accs-python-app/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/accs-python-app/python-app/app.py
+++ b/examples/oraclepaas/accs-python-app/python-app/app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
-
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 import os
 from http.server import BaseHTTPRequestHandler, HTTPServer

--- a/examples/oraclepaas/accs-ruby-app/main.tf
+++ b/examples/oraclepaas/accs-ruby-app/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/dbcs-instance-classic/main.tf
+++ b/examples/oraclepaas/dbcs-instance-classic/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/dbcs-instance-oci/main.tf
+++ b/examples/oraclepaas/dbcs-instance-oci/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/dbcs-instance-oci/vcn.tf
+++ b/examples/oraclepaas/dbcs-instance-oci/vcn.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 resource "oci_core_virtual_network" "tf-vcn1" {
   cidr_block     = "10.0.0.0/16"

--- a/examples/oraclepaas/full-db-jcs-oci/identity.tf
+++ b/examples/oraclepaas/full-db-jcs-oci/identity.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 data "oci_identity_compartment" "compartment" {
   id = "${var.compartment_ocid}"

--- a/examples/oraclepaas/full-db-jcs-oci/main.tf
+++ b/examples/oraclepaas/full-db-jcs-oci/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 data "oci_identity_availability_domains" "ADs" {
   compartment_id = "${var.tenancy_ocid}"

--- a/examples/oraclepaas/full-db-jcs-oci/providers.tf
+++ b/examples/oraclepaas/full-db-jcs-oci/providers.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 // OCI provider (for service deployment)
 provider "oci" {

--- a/examples/oraclepaas/full-db-jcs-oci/variables.tf
+++ b/examples/oraclepaas/full-db-jcs-oci/variables.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/full-dbcs-jcs-otd-classic/main.tf
+++ b/examples/oraclepaas/full-dbcs-jcs-otd-classic/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/jcs-instance-classic/main.tf
+++ b/examples/oraclepaas/jcs-instance-classic/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/jcs-instance-oci/main.tf
+++ b/examples/oraclepaas/jcs-instance-oci/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/mysqlcs-instance-classic/main.tf
+++ b/examples/oraclepaas/mysqlcs-instance-classic/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable user {}
 variable password {}

--- a/examples/oraclepaas/mysqlcs-instance-oci/main.tf
+++ b/examples/oraclepaas/mysqlcs-instance-oci/main.tf
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 variable "user" {}
 variable "password" {}


### PR DESCRIPTION
Adds UPL License reference in comments after the copyright statement as outlined at https://oss.oracle.com/licenses/upl/#_How_should_I