### PR TITLE
Update OCI example syntax to be v0.12 compatible

### DIFF
--- a/examples/oci/connect_vcns_using_multiple_vnics/bridge.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/bridge.tf
@@ -21,13 +21,9 @@ resource "oci_core_instance_configuration" "bridge_instance_configuration" {
       display_name   = "BridgeInstance"
       shape          = "${var.InstanceShape}"
 
-      metadata {
+      metadata = {
         ssh_authorized_keys = "${file(var.ssh_public_key_path)}"
         user_data           = "${base64encode(file("user_data.tpl"))}"
-      }
-
-      timeouts {
-        create = "10m"
       }
     }
 
@@ -40,6 +36,10 @@ resource "oci_core_instance_configuration" "bridge_instance_configuration" {
       }
     }
   }
+
+  timeouts {
+    create = "10m"
+  }
 }
 
 resource "oci_core_instance_pool" "bridge_instance_pool" {
@@ -48,7 +48,7 @@ resource "oci_core_instance_pool" "bridge_instance_pool" {
   instance_configuration_id = "${oci_core_instance_configuration.bridge_instance_configuration.id}"
 
   placement_configurations {
-    availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+    availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
     primary_subnet_id   = "${oci_core_subnet.MgmtSubnet.id}"
 
     secondary_vnic_subnets {
@@ -86,7 +86,7 @@ resource "null_resource" "configure-secondary-vnic" {
   provisioner "remote-exec" {
     inline = [
       "sudo chmod 777 /tmp/secondary_vnic_all_configure.sh",
-      "sudo /tmp/secondary_vnic_all_configure.sh -c ${lookup(data.oci_core_private_ips.BridgeInstancePrivateIP2.private_ips[0],"id")}",
+      "sudo /tmp/secondary_vnic_all_configure.sh -c ${lookup(data.oci_core_private_ips.BridgeInstancePrivateIP2.private_ips[0], "id")}",
       "sudo ip route add ${var.vcn_cidr2} dev ens4 via ${oci_core_subnet.MgmtSubnet2.virtual_router_ip}",
     ]
   }

--- a/examples/oci/connect_vcns_using_multiple_vnics/datasources.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/datasources.tf
@@ -7,7 +7,7 @@ data "oci_identity_availability_domains" "ADs" {
 ###### BRIDGE INSTANCE #########
 # Get Bridge instance object from instance pool
 data "oci_core_instance" "bridge_instance" {
-  instance_id = "${lookup(data.oci_core_instance_pool_instances.bridge_instance_pool_instances.instances[0],"id")}"
+  instance_id = "${lookup(data.oci_core_instance_pool_instances.bridge_instance_pool_instances.instances[0], "id")}"
 }
 
 data "oci_core_instance_pool_instances" "bridge_instance_pool_instances" {
@@ -26,19 +26,19 @@ data "oci_core_private_ips" "BridgeInstancePrivateIP2" {
 # Get the OCID of the primary VNIC
 data "oci_core_vnic" "BridgeInstanceVnic1" {
   depends_on = ["oci_core_instance_pool.bridge_instance_pool"]
-  vnic_id    = "${lookup(data.oci_core_vnic_attachments.BridgeInstanceVnicAttachmentPrimary.vnic_attachments[0],"vnic_id")}"
+  vnic_id    = "${lookup(data.oci_core_vnic_attachments.BridgeInstanceVnicAttachmentPrimary.vnic_attachments[0], "vnic_id")}"
 }
 
 # Get the OCID of the secondary VNIC
 data "oci_core_vnic" "BridgeInstanceVnic2" {
   depends_on = ["oci_core_instance_pool.bridge_instance_pool"]
-  vnic_id    = "${lookup(data.oci_core_vnic_attachments.BridgeInstanceVnicAttachmentSecondary.vnic_attachments[0],"vnic_id")}"
+  vnic_id    = "${lookup(data.oci_core_vnic_attachments.BridgeInstanceVnicAttachmentSecondary.vnic_attachments[0], "vnic_id")}"
 }
 
 data "oci_core_vnic_attachments" "BridgeInstanceVnicAttachmentPrimary" {
   depends_on          = ["oci_core_instance_pool.bridge_instance_pool"]
   compartment_id      = "${var.compartment_ocid}"
-  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
   instance_id         = "${data.oci_core_instance.bridge_instance.id}"
 
   filter {
@@ -52,7 +52,7 @@ data "oci_core_vnic_attachments" "BridgeInstanceVnicAttachmentPrimary" {
 
 data "oci_core_vnic_attachments" "BridgeInstanceVnicAttachmentSecondary" {
   compartment_id      = "${var.compartment_ocid}"
-  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
   instance_id         = "${data.oci_core_instance.bridge_instance.id}"
 
   filter {

--- a/examples/oci/connect_vcns_using_multiple_vnics/output.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/output.tf
@@ -1,30 +1,30 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved
 // Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 # Outputing required info for users
-output "Bridge Instance Public IP" {
+output "Bridge_Instance_Public_IP" {
   value = "${data.oci_core_instance.bridge_instance.public_ip}"
 }
 
-output "PrivateInstance1 Private IP" {
+output "PrivateInstance1_Private_IP" {
   value = "${oci_core_instance.PrivateInstance.private_ip}"
 }
 
-output "PrivateInstance2 Private IP" {
+output "PrivateInstance2_Private_IP" {
   value = "${oci_core_instance.PrivateInstance2.private_ip}"
 }
 
-output "SSH login to the Bridge Instance" {
+output "SSH_login_to_the_Bridge_Instance" {
   value = "ssh -A opc@${data.oci_core_instance.bridge_instance.public_ip}"
 }
 
-output "SSH login to the Private Instance-1 after logging into Bridge Instance as shown above" {
+output "SSH_login_to_the_Private_Instance-1_after_logging_into_Bridge_Instance_as_shown_above" {
   value = "ssh -A opc@${oci_core_instance.PrivateInstance.private_ip}"
 }
 
-output "SSH login to the Private Instance-2 after logging into Bridge Instance as shown above" {
+output "SSH_login_to_the_Private_Instance-2_after_logging_into_Bridge_Instance_as_shown_above" {
   value = "ssh -A opc@${oci_core_instance.PrivateInstance2.private_ip}"
 }
 
-output "Ping from PrivateInstance-1 to PrivateInstance-2" {
+output "Ping_from_PrivateInstance-1_to_PrivateInstance-2" {
   value = "ping ${oci_core_instance.PrivateInstance2.private_ip} "
 }

--- a/examples/oci/connect_vcns_using_multiple_vnics/vcn1.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/vcn1.tf
@@ -29,42 +29,43 @@ resource "oci_core_security_list" "MgmtSecurityList" {
   display_name   = "MgmtSecurityList"
   vcn_id         = "${oci_core_virtual_network.CoreVCN.id}"
 
-  egress_security_rules = [{
+  egress_security_rules {
     protocol    = "all"
     destination = "0.0.0.0/0"
-  }]
+  }
 
-  ingress_security_rules = [{
+  ingress_security_rules {
     protocol = "all"
     source   = "${var.vcn_cidr}"
-  },
-    {
-      protocol = "all"
-      source   = "${var.vcn_cidr2}"
-    },
-    {
-      protocol = "6"
-      source   = "0.0.0.0/0"
+  }
 
-      tcp_options {
-        "min" = 22
-        "max" = 22
-      }
-    },
-    {
-      protocol = "1"
-      source   = "0.0.0.0/0"
+  ingress_security_rules {
+    protocol = "all"
+    source   = "${var.vcn_cidr2}"
+  }
 
-      icmp_options {
-        "type" = 3
-        "code" = 4
-      }
-    },
-  ]
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+  ingress_security_rules {
+    protocol = "1"
+    source   = "0.0.0.0/0"
+
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
 }
 
 resource "oci_core_subnet" "MgmtSubnet" {
-  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
   cidr_block          = "${var.mgmt_subnet_cidr}"
   display_name        = "MgmtSubnet"
   compartment_id      = "${var.compartment_ocid}"
@@ -80,20 +81,20 @@ resource "oci_core_security_list" "PrivateSecurityList" {
   display_name   = "PrivateSecurityList"
   vcn_id         = "${oci_core_virtual_network.CoreVCN.id}"
 
-  egress_security_rules = [{
+  egress_security_rules {
     protocol    = "all"
     destination = "0.0.0.0/0"
-  }]
+  }
 
-  ingress_security_rules = [{
+  ingress_security_rules {
     protocol = "all"
     source   = "${var.vcn_cidr}"
-  },
-    {
-      protocol = "all"
-      source   = "${var.vcn_cidr2}"
-    },
-  ]
+  }
+
+  ingress_security_rules {
+    protocol = "all"
+    source   = "${var.vcn_cidr2}"
+  }
 }
 
 resource "oci_core_route_table" "PrivateRouteTable" {
@@ -108,7 +109,7 @@ resource "oci_core_route_table" "PrivateRouteTable" {
 }
 
 resource "oci_core_subnet" "PrivateSubnet" {
-  availability_domain        = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  availability_domain        = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
   cidr_block                 = "${var.private_subnet_cidr}"
   display_name               = "PrivateSubnet"
   compartment_id             = "${var.compartment_ocid}"
@@ -120,7 +121,7 @@ resource "oci_core_subnet" "PrivateSubnet" {
 }
 
 resource "oci_core_instance" "PrivateInstance" {
-  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
   compartment_id      = "${var.compartment_ocid}"
   display_name        = "PrivateInstance"
   image               = "${var.InstanceImageOCID[var.region]}"
@@ -131,7 +132,7 @@ resource "oci_core_instance" "PrivateInstance" {
     assign_public_ip = false
   }
 
-  metadata {
+  metadata = {
     ssh_authorized_keys = "${file(var.ssh_public_key_path)}"
   }
 

--- a/examples/oci/connect_vcns_using_multiple_vnics/vcn2.tf
+++ b/examples/oci/connect_vcns_using_multiple_vnics/vcn2.tf
@@ -13,38 +13,37 @@ resource "oci_core_security_list" "MgmtSecurityList2" {
   display_name   = "MgmtSecurityList2"
   vcn_id         = "${oci_core_virtual_network.CoreVCN2.id}"
 
-  egress_security_rules = [{
+  egress_security_rules {
     protocol    = "all"
     destination = "0.0.0.0/0"
-  }]
+  }
 
-  ingress_security_rules = [{
+  ingress_security_rules {
     protocol = "all"
     source   = "${var.vcn_cidr2}"
-  },
-    {
-      protocol = "6"
-      source   = "0.0.0.0/0"
+  }
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
 
-      tcp_options {
-        "min" = 22
-        "max" = 22
-      }
-    },
-    {
-      protocol = "1"
-      source   = "0.0.0.0/0"
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+  ingress_security_rules {
+    protocol = "1"
+    source   = "0.0.0.0/0"
 
-      icmp_options {
-        "type" = 3
-        "code" = 4
-      }
-    },
-  ]
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
 }
 
 resource "oci_core_subnet" "MgmtSubnet2" {
-  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
   cidr_block          = "${var.mgmt_subnet_cidr2}"
   display_name        = "MgmtSubnet2"
   compartment_id      = "${var.compartment_ocid}"
@@ -59,20 +58,19 @@ resource "oci_core_security_list" "PrivateSecurityList2" {
   display_name   = "PrivateSecurityList2"
   vcn_id         = "${oci_core_virtual_network.CoreVCN2.id}"
 
-  egress_security_rules = [{
+  egress_security_rules {
     protocol    = "all"
     destination = "0.0.0.0/0"
-  }]
+  }
 
-  ingress_security_rules = [{
+  ingress_security_rules {
     protocol = "all"
     source   = "${var.vcn_cidr}"
-  },
-    {
-      protocol = "all"
-      source   = "${var.vcn_cidr2}"
-    },
-  ]
+  }
+  ingress_security_rules {
+    protocol = "all"
+    source   = "${var.vcn_cidr2}"
+  }
 }
 
 resource "oci_core_route_table" "PrivateRouteTable2" {
@@ -82,12 +80,12 @@ resource "oci_core_route_table" "PrivateRouteTable2" {
 
   route_rules {
     cidr_block        = "0.0.0.0/0"
-    network_entity_id = "${lookup(data.oci_core_private_ips.BridgeInstancePrivateIP2.private_ips[0],"id")}"
+    network_entity_id = "${lookup(data.oci_core_private_ips.BridgeInstancePrivateIP2.private_ips[0], "id")}"
   }
 }
 
 resource "oci_core_subnet" "PrivateSubnet2" {
-  availability_domain        = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  availability_domain        = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
   cidr_block                 = "${var.private_subnet_cidr2}"
   display_name               = "PrivateSubnet2"
   compartment_id             = "${var.compartment_ocid}"
@@ -99,7 +97,7 @@ resource "oci_core_subnet" "PrivateSubnet2" {
 }
 
 resource "oci_core_instance" "PrivateInstance2" {
-  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.AD - 1], "name")}"
   compartment_id      = "${var.compartment_ocid}"
   display_name        = "PrivateInstance2"
   image               = "${var.InstanceImageOCID[var.region]}"
@@ -110,7 +108,7 @@ resource "oci_core_instance" "PrivateInstance2" {
     assign_public_ip = false
   }
 
-  metadata {
+  metadata = {
     ssh_authorized_keys = "${file(var.ssh_public_key_path)}"
   }
 


### PR DESCRIPTION
This makes it compatible with both v0.11 and v0.12 Terraform

Also ran `terraform fmt` to format the examples.