### PR TITLE
Update opc and oraclepaas examples for HCL v0.12 compatibility

### DIFF
--- a/examples/opc/bastion-host-provisioning/main.tf
+++ b/examples/opc/bastion-host-provisioning/main.tf
@@ -26,7 +26,7 @@ resource "opc_compute_ssh_key" "instance" {
 }
 
 module "bastion-host" {
-  source             = "modules/bastion"
+  source             = "./modules/bastion"
   ssh_public_key     = "${opc_compute_ssh_key.bastion.name}"
   ssh_private_key    = "${file("./bastion_id_rsa")}"
   private_ip_network = "${opc_compute_ip_network.private-ip-network.name}"

--- a/examples/opc/bastion-host-provisioning/modules/bastion/variables.tf
+++ b/examples/opc/bastion-host-provisioning/modules/bastion/variables.tf
@@ -6,7 +6,7 @@ variable "ssh_public_key" {
 }
 
 variable "ssh_private_key" {
-  description = "(Required) SSH private key. E.g. `${file("~/.ssh/id_rsa")}`"
+  description = "(Required) SSH private key."
 }
 
 variable "ssh_user" {

--- a/examples/opc/ipnetworks/modules/install_ssh_keys/main.tf
+++ b/examples/opc/ipnetworks/modules/install_ssh_keys/main.tf
@@ -9,7 +9,7 @@ variable "ssh_user" {}
 
 // Install the private ssh key used to access the other hosts
 resource "null_resource" "install_ssh_keys" {
-  triggers {
+  triggers = {
     compute_instance = "${var.trigger}"
   }
 

--- a/examples/opc/loadbalancer-classic/main.tf
+++ b/examples/opc/loadbalancer-classic/main.tf
@@ -1,6 +1,10 @@
 // Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
+terraform {
+  required_version = "~> 0.11.0"
+}
+
 provider "opc" {
   version         = "~>1.2"
   user            = "${var.user}"

--- a/examples/opc/orchestrated-instance/main.tf
+++ b/examples/opc/orchestrated-instance/main.tf
@@ -7,7 +7,7 @@ variable "domain" {}
 variable "endpoint" {}
 
 provider "opc" {
-  version         = "~> 1.0.1"
+  version         = "> 1.0.1"
   user            = "${var.user}"
   password        = "${var.password}"
   identity_domain = "${var.domain}"

--- a/examples/opc/windows-instance-with-rdp/windows-server.tf
+++ b/examples/opc/windows-instance-with-rdp/windows-server.tf
@@ -9,7 +9,7 @@ provider "opc" {
 }
 
 data "template_file" "userdata" {
-  vars {
+  vars = {
     admin_password = "${var.administrator_password}"
   }
 

--- a/examples/oraclepaas/accs-php-app/main.tf
+++ b/examples/oraclepaas/accs-php-app/main.tf
@@ -8,8 +8,7 @@ variable compute_endpoint {}
 variable storage_endpoint {}
 
 provider "oraclepaas" {
-  # version              = "~> 1.3"
-  version              = "0.0.0"
+  version              = "> 1.3.0"
   user                 = "${var.user}"
   password             = "${var.password}"
   identity_domain      = "${var.domain}"
@@ -17,8 +16,7 @@ provider "oraclepaas" {
 }
 
 provider "opc" {
-  # version          = "~> 1.1"
-  version          = "0.0.0"
+  version          = "> 1.1.0"
   user             = "${var.user}"
   password         = "${var.password}"
   identity_domain  = "${var.domain}"

--- a/examples/oraclepaas/dbcs-instance-oci/main.tf
+++ b/examples/oraclepaas/dbcs-instance-oci/main.tf
@@ -52,13 +52,11 @@ resource "oci_core_subnet" "subnet" {
   compartment_id      = "${var.compartment_ocid}"
   vcn_id              = "${oci_core_virtual_network.tf-vcn1.id}"
   security_list_ids   = ["${oci_core_virtual_network.tf-vcn1.default_security_list_id}"]
-  vcn_id              = "${oci_core_virtual_network.tf-vcn1.id}"
   route_table_id      = "${oci_core_virtual_network.tf-vcn1.default_route_table_id}"
   dhcp_options_id     = "${oci_core_virtual_network.tf-vcn1.default_dhcp_options_id}"
 }
 
 resource "oraclepaas_database_service_instance" "database" {
-  count             = 1
   name              = "${local.database_service_name}"
   description       = "Created by Terraform"
   version           = "12.2.0.1"

--- a/examples/oraclepaas/dbcs-instance-oci/vcn.tf
+++ b/examples/oraclepaas/dbcs-instance-oci/vcn.tf
@@ -19,7 +19,7 @@ resource "oci_core_default_route_table" "tf-default-route-table" {
   display_name               = "tf-default-route-table"
 
   route_rules {
-    cidr_block        = "0.0.0.0/0"
+    destination       = "0.0.0.0/0"
     network_entity_id = "${oci_core_internet_gateway.tf-ig1.id}"
   }
 }
@@ -30,7 +30,7 @@ resource "oci_core_route_table" "tf-route-table1" {
   display_name   = "tf-route-table1"
 
   route_rules {
-    cidr_block        = "0.0.0.0/0"
+    destination       = "0.0.0.0/0"
     network_entity_id = "${oci_core_internet_gateway.tf-ig1.id}"
   }
 }
@@ -75,8 +75,8 @@ resource "oci_core_default_security_list" "tf-default-security-list" {
     stateless   = true
 
     udp_options {
-      "min" = 319
-      "max" = 320
+      min = 319
+      max = 320
     }
   }
 
@@ -87,8 +87,8 @@ resource "oci_core_default_security_list" "tf-default-security-list" {
     stateless = false
 
     tcp_options {
-      "min" = 22
-      "max" = 22
+      min = 22
+      max = 22
     }
   }
 
@@ -99,8 +99,8 @@ resource "oci_core_default_security_list" "tf-default-security-list" {
     stateless = true
 
     icmp_options {
-      "type" = 3
-      "code" = 4
+      type = 3
+      code = 4
     }
   }
 }

--- a/examples/oraclepaas/jcs-instance-oci/main.tf
+++ b/examples/oraclepaas/jcs-instance-oci/main.tf
@@ -18,6 +18,10 @@ variable user_ocid {}
 variable private_key_path {}
 variable fingerprint {}
 
+terraform {
+  required_version = "~> 0.11.0"
+}
+
 provider "oraclepaas" {
   user            = "${var.user}"
   password        = "${var.password}"
@@ -36,7 +40,7 @@ provider "oci" {
 data "terraform_remote_state" "database" {
   backend = "local"
 
-  config {
+  config = {
     path = "../dbcs-instance-oci/terraform.tfstate"
   }
 }


### PR DESCRIPTION
Updates the `opc` and `oraclepaas` examples for Terraform v0.11 and v0.12 compatibility